### PR TITLE
Move inputenc for better support of umlauts

### DIFF
--- a/thesis-example.tex
+++ b/thesis-example.tex
@@ -78,6 +78,11 @@
 %\listfiles
 
 % **************************************************
+% file's character encoding
+% **************************************************
+\usepackage[utf8]{inputenc}
+
+% **************************************************
 % Information and Commands for Reuse
 % **************************************************
 \newcommand{\thesisTitle}{The Clean Thesis Style}
@@ -108,7 +113,6 @@
 % **************************************************
 % Load and Configure Packages
 % **************************************************
-\usepackage[utf8]{inputenc}		% defines file's character encoding
 \usepackage[english]{babel} % babel system, adjust the language of the content
 \usepackage[					% clean thesis style
 	figuresep=colon,%


### PR DESCRIPTION
To provide umlauts within the custom commands, the `inputenc` should be placed before the definition of those commands
